### PR TITLE
Do not allow for missing values in Julia

### DIFF
--- a/juliadf/groupby-juliadf.jl
+++ b/juliadf/groupby-juliadf.jl
@@ -20,7 +20,7 @@ data_name = ENV["SRC_GRP_LOCAL"];
 src_grp = string("data/", data_name, ".csv")
 println(string("loading dataset ", data_name)); flush(stdout);
 
-x = CSV.read(src_grp, categorical=0.05);
+x = CSV.read(src_grp, categorical=0.05, allowmissing=:none);
 in_rows = size(x, 1);
 println(in_rows); flush(stdout);
 


### PR DESCRIPTION
One of the strengths of Julia is that it supports both columns which cannot contain missing values and columns that can, allowing for better performance when there are no missing values.

One could also use `allowmissing=:auto` to leave `CSV.read` choose automatically depending on whether missing values have been encountered (this isn't used by default since it can fail if no missing values appear in the subset of rows used for detection).