### PR TITLE
Use pool=true when reading CSV file in Julia

### DIFF
--- a/juliadf/groupby-juliadf.jl
+++ b/juliadf/groupby-juliadf.jl
@@ -20,7 +20,7 @@ data_name = ENV["SRC_GRP_LOCAL"];
 src_grp = string("data/", data_name, ".csv")
 println(string("loading dataset ", data_name)); flush(stdout);
 
-x = CSV.read(src_grp, pool=true);
+x = DataFrame(CSV.File(src_grp, pool=true));
 in_rows = size(x, 1);
 println(in_rows); flush(stdout);
 

--- a/juliadf/groupby-juliadf.jl
+++ b/juliadf/groupby-juliadf.jl
@@ -20,7 +20,7 @@ data_name = ENV["SRC_GRP_LOCAL"];
 src_grp = string("data/", data_name, ".csv")
 println(string("loading dataset ", data_name)); flush(stdout);
 
-x = CSV.read(src_grp, categorical=0.05, allowmissing=:none);
+x = CSV.read(src_grp, pool=true);
 in_rows = size(x, 1);
 println(in_rows); flush(stdout);
 


### PR DESCRIPTION
The `pool` argument replaces `categorical`, and doesn't suffer for performance problems
with large number of unique values which forced us to use `categorical=0.05`.

Cc: @bkamins