### PR TITLE
Provide types explicitly when parsing CSV for juliadf

### DIFF
--- a/juliadf/groupby-juliadf.jl
+++ b/juliadf/groupby-juliadf.jl
@@ -22,7 +22,8 @@ println(string("loading dataset ", data_name)); flush(stdout);
 
 # Types are provided explicitly only to reduce memory use when parsing
 x = DataFrame(CSV.File(src_grp, pool=true,
-                       types=[PooledString, PooledString, PooledString, Int, Int, Int, Int, Int, Float64]));
+                       types=[PooledString, PooledString, PooledString, Int, Int, Int, Int, Int, Float64]),
+              copycols=true);
 in_rows = size(x, 1);
 println(in_rows); flush(stdout);
 

--- a/juliadf/groupby-juliadf.jl
+++ b/juliadf/groupby-juliadf.jl
@@ -20,7 +20,9 @@ data_name = ENV["SRC_GRP_LOCAL"];
 src_grp = string("data/", data_name, ".csv");
 println(string("loading dataset ", data_name)); flush(stdout);
 
-x = DataFrame(CSV.File(src_grp, pool=true));
+# Types are provided explicitly only to reduce memory use when parsing
+x = DataFrame(CSV.File(src_grp, pool=true,
+                       types=[PooledString, PooledString, PooledString, Int, Int, Int, Int, Int, Float64]));
 in_rows = size(x, 1);
 println(in_rows); flush(stdout);
 

--- a/juliadf/groupby-juliadf.jl
+++ b/juliadf/groupby-juliadf.jl
@@ -22,8 +22,7 @@ println(string("loading dataset ", data_name)); flush(stdout);
 
 # Types are provided explicitly only to reduce memory use when parsing
 x = DataFrame(CSV.File(src_grp, pool=true,
-                       types=[PooledString, PooledString, PooledString, Int, Int, Int, Int, Int, Float64]),
-              copycols=true);
+                       types=[PooledString, PooledString, PooledString, Int, Int, Int, Int, Int, Float64]));
 in_rows = size(x, 1);
 println(in_rows); flush(stdout);
 


### PR DESCRIPTION
CSV.jl should be able to use less memory when types are provided explicitly, which could avoid the memory error with 50GB datasets.

See also https://github.com/h2oai/db-benchmark/pull/85 and https://github.com/JuliaData/CSV.jl/issues/432#issuecomment-541965272.