### PR TITLE
Change table order in Julia

### DIFF
--- a/juliadf/join-juliadf.jl
+++ b/juliadf/join-juliadf.jl
@@ -43,13 +43,13 @@ print("joining...\n"); flush(stdout);
 
 question = "small inner on int"; # q1
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, small, on = :id1, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(small, x, on = :id1, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(1, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
 ANS = 0;
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, small, on = :id1, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(small, x, on = :id1, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(2, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
@@ -59,13 +59,13 @@ ANS = 0;
 
 question = "medium inner on int"; # q2
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, medium, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(medium, x, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(1, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
 ANS = 0;
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, medium, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(medium, x, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(2, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
@@ -75,13 +75,13 @@ ANS = 0;
 
 question = "medium outer on int"; # q3
 GC.gc();
-t = @elapsed (ANS = leftjoin(x, medium, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = leftjoin(medium, x, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(skipmissing(ANS.v2))];
 write_log(1, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
 ANS = 0;
 GC.gc();
-t = @elapsed (ANS = leftjoin(x, medium, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = leftjoin(medium, x, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(skipmissing(ANS.v2))];
 write_log(2, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
@@ -91,14 +91,14 @@ ANS = 0;
 
 question = "medium inner on factor"; # q4
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, medium, on = :id5, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(medium, x, on = :id5, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 t_start = time_ns();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(1, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
 ANS = 0;
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, medium, on = :id5, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(medium, x, on = :id5, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(2, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
@@ -108,13 +108,13 @@ ANS = 0;
 
 question = "big inner on int"; # q5
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, big, on = :id3, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(big, x, on = :id3, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(1, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
 ANS = 0;
 GC.gc();
-t = @elapsed (ANS = innerjoin(x, big, on = :id3, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = innerjoin(big, x, on = :id3, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(ANS.v2)];
 write_log(2, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);

--- a/juliadf/join-juliadf.jl
+++ b/juliadf/join-juliadf.jl
@@ -75,13 +75,13 @@ ANS = 0;
 
 question = "medium outer on int"; # q3
 GC.gc();
-t = @elapsed (ANS = leftjoin(medium, x, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = leftjoin(x, medium, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(skipmissing(ANS.v2))];
 write_log(1, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);
 ANS = 0;
 GC.gc();
-t = @elapsed (ANS = leftjoin(medium, x, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
+t = @elapsed (ANS = leftjoin(x, medium, on = :id2, makeunique=true); println(size(ANS)); flush(stdout));
 m = memory_usage();
 chkt = @elapsed chk = [sum(ANS.v1), sum(skipmissing(ANS.v2))];
 write_log(2, task, data_name, in_rows, question, size(ANS, 1), size(ANS, 2), solution, ver, git, fun, t, m, cache, make_chk(chk), chkt, on_disk);


### PR DESCRIPTION
@jangorecki when looking at the benchmarks for `join` I have noticed that for different packages sometimes a different order of tables passed is used. In DataFrames.jl currently this order actually matters (when joining the "small" table should go first).

So my questions are:
1. would it be possible to run the benchmark against this PR and get information about the results?
2. would you consider changing this order?

Thank you!