### PR TITLE
Precompile methods in DataFrames.jl

### DIFF
--- a/juliadf/groupby-juliadf.jl
+++ b/juliadf/groupby-juliadf.jl
@@ -7,6 +7,9 @@ using CSV;
 using Statistics; # mean function
 using Printf;
 
+# Precompile methods for common patterns
+DataFrames.precompile(true)
+
 include("$(pwd())/_helpers/helpers.jl");
 
 pkgmeta = getpkgmeta("DataFrames");

--- a/juliadf/join-juliadf.jl
+++ b/juliadf/join-juliadf.jl
@@ -6,6 +6,9 @@ using DataFrames;
 using CSV;
 using Printf;
 
+# Precompile methods for common patterns
+DataFrames.precompile(true)
+
 include("$(pwd())/_helpers/helpers.jl");
 
 pkgmeta = getpkgmeta("DataFrames");


### PR DESCRIPTION
This ensures we don't include the time needed to compile common methods in the first call of benchmarks. Requires DataFrames 0.22.

Cc: @bkamins 