### PR TITLE
Polars

### DIFF
--- a/polars/groupby-polars.py
+++ b/polars/groupby-polars.py
@@ -467,7 +467,7 @@ t_start = timeit.default_timer()
 
 q = (
     x.groupby("id3")
-    .agg([col("v1").max().alias("v1"), col("v2").min().alias("v2")])
+    .agg([pl.max("v1").alias("v1"), pl.min("v2").alias("v2")])
     .select(["id3", (col("v1") - col("v2")).alias("range_v1_v2")])
 )
 ans = q.collect()
@@ -503,7 +503,7 @@ t_start = timeit.default_timer()
 
 q = (
     x.groupby("id3")
-    .agg([col("v1").max().alias("v1"), col("v2").min().alias("v2")])
+    .agg([pl.max("v1").alias("v1"), pl.min("v2").alias("v2")])
     .select(["id3", (col("v1") - col("v2")).alias("range_v1_v2")])
 )
 

--- a/polars/join-polars.py
+++ b/polars/join-polars.py
@@ -40,49 +40,50 @@ print(
     flush=True,
 )
 
-x = pl.read_csv(
-    src_jn_x,
-    dtype={
-        "id1": pl.Int32,
-        "id2": pl.Int32,
-        "id3": pl.Int32,
-        "v1": pl.Float64,
-    },
-)
-x["id4"] = x["id4"].cast(pl.Categorical)
-x["id5"] = x["id5"].cast(pl.Categorical)
-x["id6"] = x["id6"].cast(pl.Categorical)
+with pl.StringCache():
+    x = pl.read_csv(
+        src_jn_x,
+        dtype={
+            "id1": pl.Int32,
+            "id2": pl.Int32,
+            "id3": pl.Int32,
+            "v1": pl.Float64,
+        },
+    )
+    x["id4"] = x["id4"].cast(pl.Categorical)
+    x["id5"] = x["id5"].cast(pl.Categorical)
+    x["id6"] = x["id6"].cast(pl.Categorical)
 
-small = pl.read_csv(
-    src_jn_y[0],
-    dtype={
-        "id1": pl.Int32,
-        "v2": pl.Float64,
-    },
-)
-small["id4"] = small["id4"].cast(pl.Categorical)
-medium = pl.read_csv(
-    src_jn_y[1],
-    dtype={
-        "id1": pl.Int32,
-        "id2": pl.Int32,
-        "v2": pl.Float64,
-    },
-)
-medium["id4"] = medium["id4"].cast(pl.Categorical)
-medium["id5"] = medium["id5"].cast(pl.Categorical)
-big = pl.read_csv(
-    src_jn_y[2],
-    dtype={
-        "id1": pl.Int32,
-        "id2": pl.Int32,
-        "id3": pl.Int32,
-        "v2": pl.Float64,
-    },
-)
-big["id4"] = big["id4"].cast(pl.Categorical)
-big["id5"] = big["id5"].cast(pl.Categorical)
-big["id6"] = big["id6"].cast(pl.Categorical)
+    small = pl.read_csv(
+        src_jn_y[0],
+        dtype={
+            "id1": pl.Int32,
+            "v2": pl.Float64,
+        },
+    )
+    small["id4"] = small["id4"].cast(pl.Categorical)
+    medium = pl.read_csv(
+        src_jn_y[1],
+        dtype={
+            "id1": pl.Int32,
+            "id2": pl.Int32,
+            "v2": pl.Float64,
+        },
+    )
+    medium["id4"] = medium["id4"].cast(pl.Categorical)
+    medium["id5"] = medium["id5"].cast(pl.Categorical)
+    big = pl.read_csv(
+        src_jn_y[2],
+        dtype={
+            "id1": pl.Int32,
+            "id2": pl.Int32,
+            "id3": pl.Int32,
+            "v2": pl.Float64,
+        },
+    )
+    big["id4"] = big["id4"].cast(pl.Categorical)
+    big["id5"] = big["id5"].cast(pl.Categorical)
+    big["id6"] = big["id6"].cast(pl.Categorical)
 
 print(len(x), flush=True)
 print(len(small), flush=True)


### PR DESCRIPTION
Change some syntax to be more consistent with earlier queries. 

And fix a bug in the join script. When casting to categoricals there is a temporarily global string cache to make the categories consistent. This cache exists until the context_manager is closed.