### PR TITLE
py-polars was renamed to polars; continue py-polars as polars

### DIFF
--- a/polars/groupby-polars.py
+++ b/polars/groupby-polars.py
@@ -5,8 +5,8 @@ print("# groupby-polars.py", flush=True)
 import os
 import gc
 import timeit
-import pypolars as pl
-from pypolars.lazy import col
+import polars as pl
+from polars.lazy import col
 
 exec(open("./_helpers/helpers.py").read())
 

--- a/polars/join-polars.py
+++ b/polars/join-polars.py
@@ -5,7 +5,7 @@ print("# join-polars.py", flush=True)
 import os
 import gc
 import timeit
-import pypolars as pl
+import polars as pl
 
 exec(open("./_helpers/helpers.py").read())
 

--- a/polars/setup-polars.sh
+++ b/polars/setup-polars.sh
@@ -8,7 +8,7 @@ sudo apt-get install -y python3.6-dev virtualenv
 virtualenv polars/py-polars --python=/usr/bin/python3.6
 source polars/py-polars/bin/activate
 
-python -m pip install --upgrade psutil py-polars
+python -m pip install --upgrade psutil polars
 
 # build
 deactivate
@@ -17,7 +17,7 @@ deactivate
 # check
 source polars/py-polars/bin/activate
 python
-import pypolars as pl
+import polars as pl
 pl.__version__
 quit()
 deactivate

--- a/polars/upg-polars.sh
+++ b/polars/upg-polars.sh
@@ -5,4 +5,4 @@ echo 'upgrading polars...'
 
 source ./polars/py-polars/bin/activate
 
-python -m pip install --upgrade py-polars > /dev/null
+python -m pip install --upgrade polars > /dev/null

--- a/polars/ver-polars.sh
+++ b/polars/ver-polars.sh
@@ -2,4 +2,4 @@
 set -e
 
 source ./polars/py-polars/bin/activate
-python -c 'import pypolars as pl; open("polars/VERSION","w").write(pl.__version__); open("polars/REVISION","w").write("");' > /dev/null
+python -c 'import polars as pl; open("polars/VERSION","w").write(pl.__version__); open("polars/REVISION","w").write("");' > /dev/null


### PR DESCRIPTION
We renamed `py-polars` to `polars`. This PR points to the new `pypi` registry. The old one won't be updated.