### PR TITLE
Add deprecation notice to website

### DIFF
--- a/_report/index.Rmd
+++ b/_report/index.Rmd
@@ -10,6 +10,8 @@ output:
 # Rscript -e 'rmarkdown::render("./_report/index.Rmd", output_dir="public")' && xdg-open public/index.html
 ```
 
+***Deprecation notice**: As of **July 2021** this benchmark is no longer updated*
+
 This page aims to benchmark various database-like tools popular in open-source data science. It runs regularly against very latest versions of these packages and automatically updates. We provide this as a service to both developers of these packages and to users. You can find out more about the project in [_Efficiency in data processing_ slides](https://jangorecki.gitlab.io/r-talks/2019-12-26_Mumbai_Efficiency-in-data-processing/Efficiency-in-data-processing.pdf) and [talk made by Matt Dowle on H2OWorld 2019 NYC conference](https://www.youtube.com/watch?v=fZpA_cU0SPg).
 
 We also include the syntax being timed alongside the timing. This way you can immediately see whether you are doing these tasks or not, and if the timing differences matter to you or not. A 10x difference may be irrelevant if that's just 1s vs 0.1s on your data size. The intention is that you click the tab for the size of data you have.


### PR DESCRIPTION
Right now the website states that benchmarks are continuously updated. This is no longer true as of July 2021.

It would be good to add a deprecation notice to show that the website has no longer been updated. This doesn't take away from the great work this benchmark has been. It's still useful. But it's good to be precise and not misleading.

It is not good for H2O's reputation to offer a website that is not accurate, promising continuous updates when these are not happening. This could be understood as H2O not being a stable provider that cares about keeping software properly maintained. Maybe @arnocandel @mattdowle one of you can have a look? Thanks!


Partially resolves #248 